### PR TITLE
Enable sport mode via lights toggle

### DIFF
--- a/src/firmware/app.c
+++ b/src/firmware/app.c
@@ -248,13 +248,25 @@ void app_set_lights(bool on)
 	}
 	else
 	{
-		if (g_config.lights_mode == LIGHTS_MODE_DEFAULT && lights_state != on)
-		{
-			lights_state = on;
-			eventlog_write_data(EVT_DATA_LIGHTS, on);
-			lights_set(on);
-		}
-	}
+                if (g_config.lights_mode == LIGHTS_MODE_DEFAULT && lights_state != on)
+                {
+                        bool turning_on = (!lights_state && on);
+                        lights_state = on;
+                        eventlog_write_data(EVT_DATA_LIGHTS, on);
+                        lights_set(on);
+
+                        if (
+                                turning_on &&
+                                operation_mode == OPERATION_MODE_DEFAULT &&
+                                assist_level == ASSIST_0 &&
+                                brake_is_activated() &&
+                                throttle_map_response(throttle_read()) > 90
+                           )
+                        {
+                                app_set_operation_mode(OPERATION_MODE_SPORT);
+                        }
+                }
+        }
 }
 
 void app_set_operation_mode(uint8_t mode)


### PR DESCRIPTION
## Summary
- switch to Sport mode when lights are turned on while braking with high throttle in default mode and assist level 0

## Testing
- `make TARGET_CONTROLLER=BBSHD` *(fails: sdcc: No such file or directory)*
- `apt-get install -y sdcc` *(fails: Unable to locate package sdcc)*

------
https://chatgpt.com/codex/tasks/task_e_68baad1d8ac0833297c6454f37ca840f