### PR TITLE
Add operation mode control to tool

### DIFF
--- a/src/tool/View/SystemView.xaml
+++ b/src/tool/View/SystemView.xaml
@@ -33,14 +33,15 @@
 					<ColumnDefinition />
 				</Grid.ColumnDefinitions>
 
-				<Grid.RowDefinitions>
-					<RowDefinition Height="Auto" />
-					<RowDefinition Height="Auto" />
-					<RowDefinition Height="Auto" />
-					<RowDefinition Height="Auto" />
-					<RowDefinition Height="Auto" />
-					<RowDefinition Height="Auto" />
-				</Grid.RowDefinitions>
+                                <Grid.RowDefinitions>
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                </Grid.RowDefinitions>
 
 				<TextBlock Grid.Row="0" Text="Global" FontSize="18" FontWeight="Bold" />
 
@@ -59,9 +60,15 @@
 				<TextBlock Grid.Column="0" Grid.Row="5" Margin="0 10 0 0" Text="Max Speed (km/h):" Visibility="{Binding ConfigVm.UseMetricUnits, Converter={StaticResource BoolToVis}}" />
 				<TextBox Grid.Column="2" Grid.Row="5" Margin="0 10 0 0" Width="60" HorizontalAlignment="Right" Text="{Binding ConfigVm.MaxSpeedKph, UpdateSourceTrigger=PropertyChanged}" Visibility="{Binding ConfigVm.UseMetricUnits, Converter={StaticResource BoolToVis}}" />
 
-				<TextBlock Grid.Column="0" Grid.Row="5" Margin="0 10 0 0" Text="Max Speed (mph):" Visibility="{Binding ConfigVm.UseImperialUnits, Converter={StaticResource BoolToVis}}" />
-				<TextBox Grid.Column="2" Grid.Row="5" Margin="0 10 0 0" Width="60" HorizontalAlignment="Right" Text="{Binding ConfigVm.MaxSpeedMph, UpdateSourceTrigger=PropertyChanged}" Visibility="{Binding ConfigVm.UseImperialUnits, Converter={StaticResource BoolToVis}}" />
-			</Grid>
+                                <TextBlock Grid.Column="0" Grid.Row="5" Margin="0 10 0 0" Text="Max Speed (mph):" Visibility="{Binding ConfigVm.UseImperialUnits, Converter={StaticResource BoolToVis}}" />
+                                <TextBox Grid.Column="2" Grid.Row="5" Margin="0 10 0 0" Width="60" HorizontalAlignment="Right" Text="{Binding ConfigVm.MaxSpeedMph, UpdateSourceTrigger=PropertyChanged}" Visibility="{Binding ConfigVm.UseImperialUnits, Converter={StaticResource BoolToVis}}" />
+
+                                <TextBlock Grid.Column="0" Grid.Row="6" Margin="0 10 0 0" Text="Operation Mode:" />
+                                <StackPanel Grid.Column="2" Grid.Row="6" Margin="0 10 0 0" Orientation="Horizontal" HorizontalAlignment="Right" IsEnabled="{Binding ConnectionVm.IsConnected}">
+                                        <ComboBox Width="80" ItemsSource="{Binding OperationModeOptions}" SelectedItem="{Binding SelectedOperationMode}" />
+                                        <Button Content="Apply" Margin="10 0 0 0" Command="{Binding SetOperationModeCommand}" />
+                                </StackPanel>
+                        </Grid>
 
 			<Grid Margin="0 20 0 0">
 				<Grid.ColumnDefinitions>

--- a/src/tool/ViewModel/MainViewModel.cs
+++ b/src/tool/ViewModel/MainViewModel.cs
@@ -70,12 +70,12 @@ namespace BBSFW.ViewModel
 
 		public MainViewModel()
 		{
-			ConfigVm = new ConfigurationViewModel();
+                        ConfigVm = new ConfigurationViewModel();
 
-			ConnectionVm = new ConnectionViewModel();
-			SystemVm = new SystemViewModel(ConfigVm);
-			AssistLevelsVm = new AssistLevelsViewModel(ConfigVm);
-			CalibrationVm = new CalibrationViewModel(ConnectionVm);
+                        ConnectionVm = new ConnectionViewModel();
+                        SystemVm = new SystemViewModel(ConfigVm, ConnectionVm);
+                        AssistLevelsVm = new AssistLevelsViewModel(ConfigVm);
+                        CalibrationVm = new CalibrationViewModel(ConnectionVm);
 			EventLogVm = new EventLogViewModel();
 
 

--- a/src/tool/ViewModel/SystemViewModel.cs
+++ b/src/tool/ViewModel/SystemViewModel.cs
@@ -1,24 +1,84 @@
 using BBSFW.ViewModel.Base;
 using System;
 using System.Collections.Generic;
-using System.Text;
+using System.Windows;
+using System.Windows.Input;
 
 namespace BBSFW.ViewModel
 {
-	public class SystemViewModel : ObservableObject
-	{
+        public class SystemViewModel : ObservableObject
+        {
 
+                private ConfigurationViewModel _configVm;
+                public ConfigurationViewModel ConfigVm
+                {
+                        get { return _configVm; }
+                }
 
-		private ConfigurationViewModel _configVm;
-		public ConfigurationViewModel ConfigVm
-		{
-			get { return _configVm; }
-		}
+                private ConnectionViewModel _connectionVm;
+                public ConnectionViewModel ConnectionVm
+                {
+                        get { return _connectionVm; }
+                }
 
-		public SystemViewModel(ConfigurationViewModel config)
-		{
-			_configVm = config;
-		}
+                public static List<ValueItemViewModel<bool>> OperationModeOptions { get; } =
+                        new List<ValueItemViewModel<bool>>
+                        {
+                                new ValueItemViewModel<bool>(false, "Legal"),
+                                new ValueItemViewModel<bool>(true, "Offroad")
+                        };
 
-	}
+                private ValueItemViewModel<bool> _selectedOperationMode;
+                public ValueItemViewModel<bool> SelectedOperationMode
+                {
+                        get { return _selectedOperationMode; }
+                        set
+                        {
+                                if (_selectedOperationMode != value)
+                                {
+                                        _selectedOperationMode = value;
+                                        OnPropertyChanged(nameof(SelectedOperationMode));
+                                }
+                        }
+                }
+
+                public ICommand SetOperationModeCommand
+                {
+                        get { return new DelegateCommand(OnSetOperationMode); }
+                }
+
+                public SystemViewModel(ConfigurationViewModel config, ConnectionViewModel connectionVm)
+                {
+                        _configVm = config;
+                        _connectionVm = connectionVm;
+                        SelectedOperationMode = OperationModeOptions[0];
+                }
+
+                private async void OnSetOperationMode()
+                {
+                        if (!_connectionVm.IsConnected)
+                        {
+                                MessageBox.Show("Not Connected!", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                                return;
+                        }
+
+                        var res = await _connectionVm.GetConnection().SetOperationMode(SelectedOperationMode.Value, TimeSpan.FromSeconds(3));
+                        if (!res.Timeout)
+                        {
+                                if (res.Result)
+                                {
+                                        MessageBox.Show("Operation mode set!", "Success", MessageBoxButton.OK, MessageBoxImage.Information);
+                                }
+                                else
+                                {
+                                        MessageBox.Show("Failed to set operation mode, check log.", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                                }
+                        }
+                        else
+                        {
+                                MessageBox.Show("Failed to set operation mode, timeout occured.", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                        }
+                }
+
+        }
 }


### PR DESCRIPTION
## Summary
- Add Bafang display write-mode support with `SetOperationMode` to toggle legal/offroad.
- Expose operation mode command in SystemViewModel and pass connection in MainViewModel.
- Provide UI elements to choose and apply operation mode when connected.

## Testing
- `dotnet build src/tool/bbs-fw-tool.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68baad1fecb883328a2fc76386aea4e3