### PR TITLE
C503 temporary high-memory newspace split

### DIFF
--- a/.github/workflows/c503_mfsplit_swap.yml
+++ b/.github/workflows/c503_mfsplit_swap.yml
@@ -3,6 +3,8 @@ name: C503 High-Memory Newspace Orbit Split
 on:
   push:
     branches: [c503-mfsplit-swap-20260801]
+  pull_request:
+    branches: [master]
 
 permissions:
   contents: read

--- a/.github/workflows/c503_mfsplit_swap.yml
+++ b/.github/workflows/c503_mfsplit_swap.yml
@@ -1,0 +1,92 @@
+name: C503 High-Memory Newspace Orbit Split
+
+on:
+  push:
+    branches: [c503-mfsplit-swap-20260801]
+
+permissions:
+  contents: read
+
+jobs:
+  split:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 180
+    steps:
+      - name: Configure 48GB swap
+        shell: bash
+        run: |
+          set -euxo pipefail
+          sudo swapoff -a || true
+          sudo rm -f /swapfile
+          sudo fallocate -l 48G /swapfile
+          sudo chmod 600 /swapfile
+          sudo mkswap /swapfile
+          sudo swapon /swapfile
+          free -h
+          df -h /
+
+      - name: Build PARI-GP 2.17.4
+        shell: bash
+        run: |
+          set -euxo pipefail
+          sudo apt-get update
+          sudo apt-get install -y build-essential curl ca-certificates libgmp-dev libreadline-dev
+          curl -fL --retry 5 -o pari.tar.gz https://pari.math.u-bordeaux.fr/pub/pari/unix/pari-2.17.4.tar.gz
+          tar -xzf pari.tar.gz
+          cd pari-2.17.4
+          ./Configure --prefix="$GITHUB_WORKSPACE/pari-install"
+          make -j2 gp
+          make install
+          echo 'print(version());quit' | "$GITHUB_WORKSPACE/pari-install/bin/gp" -fq
+
+      - name: Compute all coefficient fields of degree at most 30
+        shell: bash
+        run: |
+          set -euxo pipefail
+          mkdir -p out_split
+          cat > split.gp <<'GP'
+          default(parisizemax,56000000000);
+          default(parisize,1000000000);
+          print("STACKS ",default(parisize)," ",default(parisizemax));
+          t0=getwalltime();
+          MF=mfinit([333839,2],0);
+          if(type(MF)!="t_VEC",error("mfinit failed type=",type(MF)));
+          print("MFINIT_OK dim=",mfdim(MF)," elapsed_ms=",getwalltime()-t0);
+          write("out_split/stage.gp","mfinit_ok=1");
+          write("out_split/stage.gp",Str("newspace_dimension=",mfdim(MF)));
+          t1=getwalltime();
+          S=mfsplit(MF,30,30);
+          if(type(S)!="t_VEC" || #S!=2,error("mfsplit failed type/len=",type(S),"/",#S));
+          degs=apply(poldegree,S[2]);
+          print("MFSPLIT_OK count=",#S[2]," elapsed_ms=",getwalltime()-t1);
+          print("DEGREES ",degs);
+          writebin("out_split/split.gpbin",S);
+          write("out_split/fields.txt",S[2]);
+          write("out_split/metadata.gp",Str("newspace_dimension=",mfdim(MF)));
+          write("out_split/metadata.gp",Str("orbit_count_degree_le30=",#S[2]));
+          write("out_split/metadata.gp",Str("degrees=",degs));
+          print("C503_MFSPLIT_CERTIFIED");
+          quit
+          GP
+          export LD_LIBRARY_PATH="$GITHUB_WORKSPACE/pari-install/lib"
+          set +e
+          /usr/bin/time -v "$GITHUB_WORKSPACE/pari-install/bin/gp" -fq < split.gp > out_split/stdout.log 2> out_split/stderr.log
+          RC=$?
+          set -e
+          echo "$RC" > out_split/exit_code.txt
+          free -h > out_split/memory_after.txt
+          df -h / > out_split/disk_after.txt
+          sha256sum out_split/* > out_split/SHA256SUMS.txt || true
+          cat out_split/stdout.log
+          tail -n 200 out_split/stderr.log
+          test "$RC" -eq 0
+          grep -q '^C503_MFSPLIT_CERTIFIED$' out_split/stdout.log
+
+      - name: Upload split diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: c503-mfsplit-degree30-swap
+          path: out_split
+          if-no-files-found: warn
+          retention-days: 3


### PR DESCRIPTION
Temporary draft PR used only to compute and freeze the level-333839 orbit inventory for the C404 arithmetic audit. It is not intended to merge.