### PR TITLE
C509 temporary eclib q_bc modular-symbol audit

### DIFF
--- a/.github/workflows/c509_eclib_common.yml
+++ b/.github/workflows/c509_eclib_common.yml
@@ -1,0 +1,122 @@
+name: C509 eclib Common Pair Lattice
+
+on:
+  push:
+    branches: [c509-eclib-qbc-20260803]
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  compute-common:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 240
+    steps:
+      - name: Configure swap and install eclib
+        shell: bash
+        run: |
+          set -euxo pipefail
+          sudo swapoff -a || true
+          sudo rm -f /swapfile
+          sudo fallocate -l 40G /swapfile
+          sudo chmod 600 /swapfile
+          sudo mkswap /swapfile
+          sudo swapon /swapfile
+          sudo apt-get update
+          sudo apt-get install -y build-essential eclib-tools libec-dev libpari-dev libntl-dev libflint-dev libmpfr-dev libboost-system-dev libboost-thread-dev
+          free -h
+
+      - name: Build common-basis program
+        shell: bash
+        run: |
+          set -euxo pipefail
+          mkdir -p out
+          cat > c509_eclib_common.cc <<'CPP'
+          #include <iostream>
+          #include <sstream>
+          #include <string>
+          #include <vector>
+          #include <eclib/newforms.h>
+          #include <eclib/curve.h>
+          using std::cout; using std::endl; using std::string; using std::vector;
+          ZZ zz(const char* s){ ZZ x; std::stringstream ss; ss<<s; ss>>x; return x; }
+          CurveRed curve(const char* a4,const char* a6){ Curve C(ZZ(0),ZZ(-1),ZZ(1),zz(a4),zz(a6)); Curvedata CD(C,1); return CurveRed(CD); }
+          void dump_vec(const char* name,const vec& v){ cout<<name<<" length="<<v.dim()<<" vector="<<v<<endl; }
+          int main(){
+            set_precision(100);
+            CurveRed A=curve("-5698610837","-165575711809938");
+            CurveRed B=curve("-47095957","124416608755");
+            long N=I2long(getconductor(A));
+            if(I2long(getconductor(B))!=N){ cout<<"CONDUCTOR_MISMATCH"<<endl; return 2; }
+            vector<CurveRed> curves; curves.push_back(A); curves.push_back(B);
+            cout<<"START_COMMON conductor="<<N<<endl;
+            newforms nf(N,1);
+            nf.createfromcurves(0,curves,100);
+            cout<<"COMMON_CREATED count="<<nf.n1ds<<endl;
+            if(nf.n1ds!=2){ cout<<"BAD_COUNT "<<nf.n1ds<<endl; return 3; }
+            nf.sort_into_LMFDB_label_order();
+            nf.make_projcoord();
+            for(long i=0;i<2;i++){
+              newform& f=nf.nflist[i];
+              cout<<"FORM index="<<i
+                  <<" loverp="<<f.loverp
+                  <<" type="<<f.type
+                  <<" denomplus="<<f.denomplus
+                  <<" denomminus="<<f.denomminus
+                  <<" contplus="<<f.contplus
+                  <<" contminus="<<f.contminus
+                  <<" optplus="<<f.optimalityfactorplus
+                  <<" optminus="<<f.optimalityfactorminus
+                  <<" degphi="<<f.degphi
+                  <<" sfe="<<f.sfe<<endl;
+              dump_vec((string("BPLUS_")+std::to_string(i)).c_str(),f.bplus);
+              dump_vec((string("BMINUS_")+std::to_string(i)).c_str(),f.bminus);
+              dump_vec((string("COORDSPLUS_")+std::to_string(i)).c_str(),f.coordsplus);
+              dump_vec((string("COORDSMINUS_")+std::to_string(i)).c_str(),f.coordsminus);
+              rational zero(0,1);
+              cout<<"INFTY0 index="<<i
+                  <<" plus="<<nf.plus_modular_symbol(zero,i,1)
+                  <<" minus="<<nf.minus_modular_symbol(zero,i,1)<<endl;
+              for(long a=1;a<11;a++){
+                rational r(a,11);
+                cout<<"CUSP index="<<i<<" a="<<a
+                    <<" plus="<<nf.plus_modular_symbol(r,i,1)
+                    <<" minus="<<nf.minus_modular_symbol(r,i,1)<<endl;
+              }
+            }
+            cout<<"C509_COMMON_CERTIFIED"<<endl;
+            return 0;
+          }
+          CPP
+          g++ -O2 -std=c++17 c509_eclib_common.cc -o c509_eclib_common -lec -lntl -lpari -lflint -lmpfr -lgmp -lboost_thread -lboost_system -lpthread
+          ldd ./c509_eclib_common > out/ldd.txt
+          sha256sum c509_eclib_common c509_eclib_common.cc > out/program_sha256.txt
+
+      - name: Run common-basis computation
+        shell: bash
+        run: |
+          set -euxo pipefail
+          set +e
+          /usr/bin/time -v ./c509_eclib_common > out/stdout.log 2> out/stderr.log
+          RC=$?
+          set -e
+          echo "$RC" > out/exit_code.txt
+          free -h > out/memory_after.txt
+          tail -n 300 out/stdout.log
+          tail -n 300 out/stderr.log
+          sha256sum out/* > out/SHA256SUMS.txt || true
+          test "$RC" -eq 0
+          grep -q '^C509_COMMON_CERTIFIED$' out/stdout.log
+
+      - name: Upload common-basis result or diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: c509-eclib-common-pair
+          path: |
+            out
+            c509_eclib_common.cc
+          if-no-files-found: warn
+          retention-days: 3

--- a/.github/workflows/c509_eclib_common.yml
+++ b/.github/workflows/c509_eclib_common.yml
@@ -43,7 +43,7 @@ jobs:
           using std::cout; using std::endl; using std::string; using std::vector;
           ZZ zz(const char* s){ ZZ x; std::stringstream ss; ss<<s; ss>>x; return x; }
           CurveRed curve(const char* a4,const char* a6){ Curve C(ZZ(0),ZZ(-1),ZZ(1),zz(a4),zz(a6)); Curvedata CD(C,1); return CurveRed(CD); }
-          void dump_vec(const char* name,const vec& v){ cout<<name<<" length="<<v.dim()<<" vector="<<v<<endl; }
+          void dump_vec(const char* name,const vec& v){ cout<<name<<" length="<<dim(v)<<" vector="<<v<<endl; }
           int main(){
             set_precision(100);
             CurveRed A=curve("-5698610837","-165575711809938");
@@ -56,7 +56,6 @@ jobs:
             nf.createfromcurves(0,curves,100);
             cout<<"COMMON_CREATED count="<<nf.n1ds<<endl;
             if(nf.n1ds!=2){ cout<<"BAD_COUNT "<<nf.n1ds<<endl; return 3; }
-            nf.sort_into_LMFDB_label_order();
             nf.make_projcoord();
             for(long i=0;i<2;i++){
               newform& f=nf.nflist[i];

--- a/.github/workflows/c509_eclib_compute.yml
+++ b/.github/workflows/c509_eclib_compute.yml
@@ -1,0 +1,142 @@
+name: C509 eclib Exact Canonical Symbols
+
+on:
+  push:
+    branches: [c509-eclib-qbc-20260803]
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  compute:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 180
+    steps:
+      - name: Configure swap and install eclib
+        shell: bash
+        run: |
+          set -euxo pipefail
+          sudo swapoff -a || true
+          sudo rm -f /swapfile
+          sudo fallocate -l 32G /swapfile
+          sudo chmod 600 /swapfile
+          sudo mkswap /swapfile
+          sudo swapon /swapfile
+          sudo apt-get update
+          sudo apt-get install -y build-essential pkg-config eclib-tools libec-dev libpari-dev libntl-dev libflint-dev libboost-system-dev libboost-thread-dev
+          pkg-config --modversion eclib
+          pkg-config --cflags --libs eclib
+          free -h
+
+      - name: Build exact canonical-symbol program
+        shell: bash
+        run: |
+          set -euxo pipefail
+          mkdir -p out
+          cat > c509_eclib_qbc.cc <<'CPP'
+          #include <iostream>
+          #include <string>
+          #include <utility>
+          #include <eclib/newforms.h>
+          #include <eclib/curve.h>
+          #include <eclib/periods.h>
+
+          using std::cout;
+          using std::endl;
+          using std::string;
+
+          const scalar modulus(default_modulus<scalar>());
+
+          ZZ zz(const char* s) {
+            ZZ x;
+            std::stringstream ss;
+            ss << s;
+            ss >> x;
+            return x;
+          }
+
+          void run_curve(const string& label, const char* a4s, const char* a6s) {
+            Curve C(ZZ(0), ZZ(-1), ZZ(1), zz(a4s), zz(a6s));
+            Curvedata CD(C, 1);
+            CurveRed CR(CD);
+            long N = I2long(getconductor(CR));
+            cout << "CURVE_BEGIN " << label << " conductor=" << N << " curve=" << (Curve)CR << endl;
+            newforms nf(N, modulus, 1);
+            nf.createfromcurve(0, CR, 80);
+            cout << "NEWFORMS_CREATED label=" << label << " count=" << nf.n1ds << endl;
+            if (nf.n1ds != 1) {
+              cout << "ERROR unexpected_newform_count=" << nf.n1ds << endl;
+              exit(2);
+            }
+            nf.make_projcoord();
+            rational zero(0,1);
+            rational pinf = nf.plus_modular_symbol(zero, 0, 1);
+            rational minf = nf.minus_modular_symbol(zero, 0, 1);
+            auto fullinf = nf.full_modular_symbol(zero, 0, 1);
+            newform& f = nf.nflist[0];
+            cout << "EXACT label=" << label
+                 << " plus_infty_0=" << pinf
+                 << " minus_infty_0=" << minf
+                 << " full_plus=" << fullinf.first
+                 << " full_minus=" << fullinf.second
+                 << " loverp=" << f.loverp
+                 << " type=" << f.type
+                 << " denomplus=" << f.denomplus
+                 << " denomminus=" << f.denomminus
+                 << " contplus=" << f.contplus
+                 << " contminus=" << f.contminus
+                 << " optimality_plus=" << f.optimalityfactorplus
+                 << " optimality_minus=" << f.optimalityfactorminus
+                 << " degphi=" << f.degphi
+                 << " sfe=" << f.sfe
+                 << endl;
+            for (long a=1; a<11; ++a) {
+              rational r(a,11);
+              cout << "CUSP label=" << label << " a=" << a
+                   << " plus=" << nf.plus_modular_symbol(r,0,1)
+                   << " minus=" << nf.minus_modular_symbol(r,0,1)
+                   << endl;
+            }
+            cout << "CURVE_END " << label << endl;
+          }
+
+          int main() {
+            set_precision(100);
+            run_curve("333839a1", "-5698610837", "-165575711809938");
+            run_curve("333839b1", "-47095957", "124416608755");
+            cout << "C509_ECLIB_CERTIFIED" << endl;
+            return 0;
+          }
+          CPP
+          g++ -O2 -std=c++17 c509_eclib_qbc.cc -o c509_eclib_qbc $(pkg-config --cflags --libs eclib)
+          ldd ./c509_eclib_qbc > out/ldd.txt
+          sha256sum c509_eclib_qbc c509_eclib_qbc.cc > out/program_sha256.txt
+
+      - name: Run exact computation
+        shell: bash
+        run: |
+          set -euxo pipefail
+          set +e
+          /usr/bin/time -v ./c509_eclib_qbc > out/stdout.log 2> out/stderr.log
+          RC=$?
+          set -e
+          echo "$RC" > out/exit_code.txt
+          free -h > out/memory_after.txt
+          cat out/stdout.log
+          tail -n 200 out/stderr.log
+          sha256sum out/* > out/SHA256SUMS.txt || true
+          test "$RC" -eq 0
+          grep -q '^C509_ECLIB_CERTIFIED$' out/stdout.log
+
+      - name: Upload result or diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: c509-eclib-exact-symbols
+          path: |
+            out
+            c509_eclib_qbc.cc
+          if-no-files-found: warn
+          retention-days: 3

--- a/.github/workflows/c509_eclib_compute.yml
+++ b/.github/workflows/c509_eclib_compute.yml
@@ -25,7 +25,7 @@ jobs:
           sudo mkswap /swapfile
           sudo swapon /swapfile
           sudo apt-get update
-          sudo apt-get install -y build-essential pkg-config eclib-tools libec-dev libpari-dev libntl-dev libflint-dev libboost-system-dev libboost-thread-dev
+          sudo apt-get install -y build-essential pkg-config eclib-tools libec-dev libpari-dev libntl-dev libflint-dev libboost-system-dev libboost-thread-dev libmpfr-dev
           pkg-config --modversion eclib
           pkg-config --cflags --libs eclib
           free -h
@@ -109,7 +109,7 @@ jobs:
             return 0;
           }
           CPP
-          g++ -O2 -std=c++17 c509_eclib_qbc.cc -o c509_eclib_qbc $(pkg-config --cflags --libs eclib)
+          g++ -O2 -std=c++17 c509_eclib_qbc.cc -o c509_eclib_qbc -lec -lntl -lpari -lflint -lmpfr -lgmp -lboost_thread -lboost_system -lpthread
           ldd ./c509_eclib_qbc > out/ldd.txt
           sha256sum c509_eclib_qbc c509_eclib_qbc.cc > out/program_sha256.txt
 

--- a/.github/workflows/c509_eclib_compute.yml
+++ b/.github/workflows/c509_eclib_compute.yml
@@ -37,6 +37,7 @@ jobs:
           mkdir -p out
           cat > c509_eclib_qbc.cc <<'CPP'
           #include <iostream>
+          #include <sstream>
           #include <string>
           #include <utility>
           #include <eclib/newforms.h>
@@ -46,8 +47,6 @@ jobs:
           using std::cout;
           using std::endl;
           using std::string;
-
-          const scalar modulus(default_modulus<scalar>());
 
           ZZ zz(const char* s) {
             ZZ x;
@@ -63,7 +62,7 @@ jobs:
             CurveRed CR(CD);
             long N = I2long(getconductor(CR));
             cout << "CURVE_BEGIN " << label << " conductor=" << N << " curve=" << (Curve)CR << endl;
-            newforms nf(N, modulus, 1);
+            newforms nf(N, 1);
             nf.createfromcurve(0, CR, 80);
             cout << "NEWFORMS_CREATED label=" << label << " count=" << nf.n1ds << endl;
             if (nf.n1ds != 1) {

--- a/.github/workflows/c509_eclib_plus.yml
+++ b/.github/workflows/c509_eclib_plus.yml
@@ -1,0 +1,108 @@
+name: C509 eclib Plus Canonical Symbols
+
+on:
+  push:
+    branches: [c509-eclib-qbc-20260803]
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  plus-symbol:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - curve: a
+            label: 333839a1
+            a4: -5698610837
+            a6: -165575711809938
+          - curve: b
+            label: 333839b1
+            a4: -47095957
+            a6: 124416608755
+    runs-on: ubuntu-24.04
+    timeout-minutes: 180
+    steps:
+      - name: Configure swap and install eclib
+        shell: bash
+        run: |
+          set -euxo pipefail
+          sudo swapoff -a || true
+          sudo rm -f /swapfile
+          sudo fallocate -l 32G /swapfile
+          sudo chmod 600 /swapfile
+          sudo mkswap /swapfile
+          sudo swapon /swapfile
+          sudo apt-get update
+          sudo apt-get install -y build-essential libec-dev libpari-dev libntl-dev libflint-dev libmpfr-dev libboost-system-dev libboost-thread-dev
+
+      - name: Build signed-plus program
+        shell: bash
+        env:
+          LABEL: ${{ matrix.label }}
+          A4: ${{ matrix.a4 }}
+          A6: ${{ matrix.a6 }}
+        run: |
+          set -euxo pipefail
+          mkdir -p out
+          cat > plus.cc <<CPP
+          #include <iostream>
+          #include <sstream>
+          #include <eclib/newforms.h>
+          #include <eclib/curve.h>
+          ZZ zz(const char*s){ZZ x;std::stringstream q;q<<s;q>>x;return x;}
+          int main(){
+            Curve C(ZZ(0),ZZ(-1),ZZ(1),zz("${A4}"),zz("${A6}"));
+            Curvedata CD(C,1); CurveRed CR(CD); long N=I2long(getconductor(CR));
+            std::cout<<"START label=${LABEL} conductor="<<N<<std::endl;
+            newforms nf(N,1); nf.createfromcurve(+1,CR,100); nf.make_projcoord();
+            if(nf.n1ds!=1){std::cout<<"BAD_COUNT "<<nf.n1ds<<std::endl;return 2;}
+            newform& f=nf.nflist[0]; rational z(0,1);
+            std::cout<<"PLUS_EXACT label=${LABEL} infty_0="<<nf.plus_modular_symbol(z,0,1)
+                     <<" zero_0="<<nf.plus_modular_symbol(z,0,0)
+                     <<" loverp="<<f.loverp
+                     <<" denomplus="<<f.denomplus
+                     <<" contplus="<<f.contplus
+                     <<" optimality_plus="<<f.optimalityfactorplus
+                     <<" degphi="<<f.degphi
+                     <<" sfe="<<f.sfe
+                     <<" bplus_length="<<f.bplus.dim()
+                     <<" coordsplus_length="<<f.coordsplus.dim()<<std::endl;
+            std::cout<<"BPLUS "<<f.bplus<<std::endl;
+            std::cout<<"COORDSPLUS "<<f.coordsplus<<std::endl;
+            for(long a=1;a<11;a++){rational r(a,11);std::cout<<"CUSP a="<<a<<" plus="<<nf.plus_modular_symbol(r,0,1)<<std::endl;}
+            std::cout<<"C509_PLUS_CERTIFIED"<<std::endl;return 0;
+          }
+          CPP
+          g++ -O2 -std=c++17 plus.cc -o plus -lec -lntl -lpari -lflint -lmpfr -lgmp -lboost_thread -lboost_system -lpthread
+          sha256sum plus plus.cc > out/program_sha256.txt
+
+      - name: Run exact plus computation
+        shell: bash
+        run: |
+          set -euxo pipefail
+          set +e
+          /usr/bin/time -v ./plus > out/stdout.log 2> out/stderr.log
+          RC=$?
+          set -e
+          echo "$RC" > out/exit_code.txt
+          free -h > out/memory_after.txt
+          tail -n 200 out/stdout.log
+          tail -n 200 out/stderr.log
+          sha256sum out/* > out/SHA256SUMS.txt || true
+          test "$RC" -eq 0
+          grep -q '^C509_PLUS_CERTIFIED$' out/stdout.log
+
+      - name: Upload result or diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: c509-eclib-plus-${{ matrix.curve }}
+          path: |
+            out
+            plus.cc
+          if-no-files-found: warn
+          retention-days: 3

--- a/.github/workflows/c509_eclib_plus.yml
+++ b/.github/workflows/c509_eclib_plus.yml
@@ -69,8 +69,8 @@ jobs:
                      <<" optimality_plus="<<f.optimalityfactorplus
                      <<" degphi="<<f.degphi
                      <<" sfe="<<f.sfe
-                     <<" bplus_length="<<f.bplus.dim()
-                     <<" coordsplus_length="<<f.coordsplus.dim()<<std::endl;
+                     <<" bplus_length="<<dim(f.bplus)
+                     <<" coordsplus_length="<<dim(f.coordsplus)<<std::endl;
             std::cout<<"BPLUS "<<f.bplus<<std::endl;
             std::cout<<"COORDSPLUS "<<f.coordsplus<<std::endl;
             for(long a=1;a<11;a++){rational r(a,11);std::cout<<"CUSP a="<<a<<" plus="<<nf.plus_modular_symbol(r,0,1)<<std::endl;}

--- a/.github/workflows/c509_eclib_qbc.yml
+++ b/.github/workflows/c509_eclib_qbc.yml
@@ -1,0 +1,51 @@
+name: C509 eclib QBC Modular Symbols
+
+on:
+  push:
+    branches: [c509-eclib-qbc-20260803]
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  inspect:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    steps:
+      - name: Install eclib tools and headers
+        shell: bash
+        run: |
+          set -euxo pipefail
+          sudo apt-get update
+          sudo apt-get install -y eclib-tools libec-dev libpari-dev libntl-dev
+
+      - name: Freeze package inventory and program help
+        shell: bash
+        run: |
+          set -euxo pipefail
+          mkdir -p out
+          dpkg-query -W -f='${Package}\t${Version}\n' eclib-tools libec-dev > out/packages.tsv
+          dpkg -L eclib-tools | sort > out/eclib-tools-files.txt
+          dpkg -L libec-dev | sort > out/libec-dev-files.txt
+          find /usr/bin -maxdepth 1 -type f -o -type l | grep -E '/(mwrank|newforms|manin|mod|ec)' | sort > out/candidate-programs.txt || true
+          while read -r prog; do
+            [ -x "$prog" ] || continue
+            name=$(basename "$prog")
+            ("$prog" --help || "$prog" -h || true) > "out/help_${name}.txt" 2>&1 || true
+          done < out/candidate-programs.txt
+          find /usr/share/doc/eclib-tools /usr/share/doc/libec-dev -type f -maxdepth 3 -print | sort > out/doc-files.txt || true
+          for f in $(cat out/doc-files.txt); do
+            case "$f" in *.gz) zcat "$f" ;; *) cat "$f" ;; esac >> out/docs-concatenated.txt 2>/dev/null || true
+          done
+          ls -lah out
+          sha256sum out/* > out/SHA256SUMS.txt
+
+      - name: Upload diagnostic
+        uses: actions/upload-artifact@v4
+        with:
+          name: c509-eclib-diagnostic
+          path: out
+          if-no-files-found: error
+          retention-days: 3


### PR DESCRIPTION
Temporary draft PR used only to inspect eclib and compute exact canonical modular-symbol data for the C404 q_bc conductor audit. It is not intended to merge.