### PR TITLE
C517 audit C516 BSD rank-zero theorem chain

### DIFF
--- a/.github/workflows/c517_c516_theorem_audit.yml
+++ b/.github/workflows/c517_c516_theorem_audit.yml
@@ -1,0 +1,89 @@
+name: C517 Audit C516 Theorem Chain
+
+on:
+  push:
+    branches: [c517-c516-proof-audit-20260810]
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    steps:
+      - name: Install tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y curl ca-certificates poppler-utils python3
+
+      - name: Download primary papers
+        shell: bash
+        run: |
+          set -euxo pipefail
+          mkdir -p out
+          curl -fL --retry 8 -A 'Mozilla/5.0' -o out/greenberg_vatsal.pdf https://arxiv.org/pdf/math/9906215.pdf
+          curl -fL --retry 8 -A 'Mozilla/5.0' -o out/jlk.pdf https://arxiv.org/pdf/0804.2828.pdf
+          curl -fL --retry 8 -A 'Mozilla/5.0' -o out/yan_zhu.pdf https://arxiv.org/pdf/2412.20078.pdf
+          file out/*.pdf | tee out/file_types.txt
+          test $(grep -c 'PDF document' out/file_types.txt) -eq 3
+          for f in greenberg_vatsal jlk yan_zhu; do pdftotext -layout "out/$f.pdf" "out/$f.txt"; done
+          pdfinfo out/greenberg_vatsal.pdf > out/greenberg_vatsal_pdfinfo.txt
+          pdfinfo out/jlk.pdf > out/jlk_pdfinfo.txt
+          pdfinfo out/yan_zhu.pdf > out/yan_zhu_pdfinfo.txt
+
+      - name: Extract exact theorem neighborhoods
+        shell: bash
+        run: |
+          set -euxo pipefail
+          cat > extract.py <<'PY'
+          import json, pathlib, re, hashlib
+          root=pathlib.Path('out')
+          def numbered(path):
+              lines=path.read_text(errors='replace').splitlines()
+              return lines
+          def neighborhoods(lines, patterns, radius=45, max_each=20):
+              ans=[]
+              for pat in patterns:
+                  rx=re.compile(pat,re.I)
+                  hits=[]
+                  for i,line in enumerate(lines):
+                      if rx.search(line):
+                          a=max(0,i-radius); b=min(len(lines),i+radius+1)
+                          hits.append({'pattern':pat,'hit_line':i+1,'start':a+1,'end':b,'text':'\n'.join(f'{j+1:06d}: {lines[j]}' for j in range(a,b))})
+                          if len(hits)>=max_each: break
+                  ans.extend(hits)
+              return ans
+          gv=numbered(root/'greenberg_vatsal.txt')
+          jlk=numbered(root/'jlk.txt')
+          yz=numbered(root/'yan_zhu.txt')
+          result={
+            'schema':'bsd-c517-primary-theorem-text-audit-v1',
+            'greenberg_vatsal': neighborhoods(gv,[r'Theorem\s+1\.4',r'Theorem\s+1\.5',r'Theorem\s+1\.2',r'Proposition\s+3\.1',r'Remark\s+3\.4',r'\Sigma_0',r'lambda.*local',r'imprimitive',r'\mu.*0']),
+            'jlk': neighborhoods(jlk,[r'Theorem\s+1\.1',r'Theorem\s+1\.2',r'Theorem\s+5\.',r'non-equivariant main conjecture',r'all prime',r'elliptic curve',r'Hecke character']),
+            'yan_zhu': neighborhoods(yz,[r'Theorem\s+5\.2',r'Theorem\s+5\.11',r'\(Im\)',r'BSD',r'characteristic ideal',r'Q_p']),
+            'sha256': {p.name:hashlib.sha256(p.read_bytes()).hexdigest() for p in root.glob('*.pdf')}
+          }
+          (root/'THEOREM_AUDIT.json').write_text(json.dumps(result,sort_keys=True,indent=2)+'\n')
+          for key in ('greenberg_vatsal','jlk','yan_zhu'):
+              with (root/(key+'_theorem_neighborhoods.txt')).open('w') as fh:
+                  for item in result[key]:
+                      fh.write('='*100+'\n')
+                      fh.write(f"PATTERN {item['pattern']} HIT {item['hit_line']} RANGE {item['start']}-{item['end']}\n")
+                      fh.write(item['text']+'\n')
+          PY
+          python3 extract.py
+          grep -n -i -E 'Theorem 1\.4|Theorem 1\.5|imprimitive|Sigma_0|lambda|mu' out/greenberg_vatsal_theorem_neighborhoods.txt | head -200 > out/gv_index.txt || true
+          grep -n -i -E 'Theorem 5\.2|Theorem 5\.11|BSD|Im' out/yan_zhu_theorem_neighborhoods.txt | head -200 > out/yz_index.txt || true
+          sha256sum out/* > out/SHA256SUMS.txt
+          ls -lh out
+
+      - name: Upload theorem audit
+        uses: actions/upload-artifact@v4
+        with:
+          name: c517-c516-theorem-audit
+          path: out
+          if-no-files-found: error
+          retention-days: 5

--- a/.github/workflows/c517_c516_theorem_audit.yml
+++ b/.github/workflows/c517_c516_theorem_audit.yml
@@ -42,9 +42,8 @@ jobs:
           import json, pathlib, re, hashlib
           root=pathlib.Path('out')
           def numbered(path):
-              lines=path.read_text(errors='replace').splitlines()
-              return lines
-          def neighborhoods(lines, patterns, radius=45, max_each=20):
+              return path.read_text(errors='replace').splitlines()
+          def neighborhoods(lines, patterns, radius=55, max_each=20):
               ans=[]
               for pat in patterns:
                   rx=re.compile(pat,re.I)
@@ -61,8 +60,8 @@ jobs:
           yz=numbered(root/'yan_zhu.txt')
           result={
             'schema':'bsd-c517-primary-theorem-text-audit-v1',
-            'greenberg_vatsal': neighborhoods(gv,[r'Theorem\s+1\.4',r'Theorem\s+1\.5',r'Theorem\s+1\.2',r'Proposition\s+3\.1',r'Remark\s+3\.4',r'\Sigma_0',r'lambda.*local',r'imprimitive',r'\mu.*0']),
-            'jlk': neighborhoods(jlk,[r'Theorem\s+1\.1',r'Theorem\s+1\.2',r'Theorem\s+5\.',r'non-equivariant main conjecture',r'all prime',r'elliptic curve',r'Hecke character']),
+            'greenberg_vatsal': neighborhoods(gv,[r'Theorem\s+\(1\.4\)',r'Theorem\s+1\.4',r'Theorem\s+\(1\.5\)',r'Theorem\s+\(1\.2\)',r'Proposition\s+3\.1',r'Remark\s+3\.4',r'Sigma.?0',r'lambda.*local',r'imprimitive',r'mu.*0']),
+            'jlk': neighborhoods(jlk,[r'Theorem\s+1\.1',r'Theorem\s+1\.2',r'Theorem\s+5\.',r'non.?equivariant main conjecture',r'all prime',r'elliptic curve',r'Hecke character']),
             'yan_zhu': neighborhoods(yz,[r'Theorem\s+5\.2',r'Theorem\s+5\.11',r'\(Im\)',r'BSD',r'characteristic ideal',r'Q_p']),
             'sha256': {p.name:hashlib.sha256(p.read_bytes()).hexdigest() for p in root.glob('*.pdf')}
           }
@@ -75,12 +74,13 @@ jobs:
                       fh.write(item['text']+'\n')
           PY
           python3 extract.py
-          grep -n -i -E 'Theorem 1\.4|Theorem 1\.5|imprimitive|Sigma_0|lambda|mu' out/greenberg_vatsal_theorem_neighborhoods.txt | head -200 > out/gv_index.txt || true
-          grep -n -i -E 'Theorem 5\.2|Theorem 5\.11|BSD|Im' out/yan_zhu_theorem_neighborhoods.txt | head -200 > out/yz_index.txt || true
+          grep -n -i -E 'Theorem.*1\.4|Theorem.*1\.5|imprimitive|Sigma|lambda|mu' out/greenberg_vatsal_theorem_neighborhoods.txt | head -300 > out/gv_index.txt || true
+          grep -n -i -E 'Theorem 5\.2|Theorem 5\.11|BSD|Im' out/yan_zhu_theorem_neighborhoods.txt | head -300 > out/yz_index.txt || true
           sha256sum out/* > out/SHA256SUMS.txt
           ls -lh out
 
       - name: Upload theorem audit
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: c517-c516-theorem-audit

--- a/.github/workflows/c517_residual_sturm.yml
+++ b/.github/workflows/c517_residual_sturm.yml
@@ -30,41 +30,38 @@ jobs:
           q1=31;
           q2=89;
           N=N0*q1*q2;
-          index=N*(1+1/11)*(1+1/31)*(1+1/89);
-          B=floor(2*index/12);
+          idx=N*(1+1/11)*(1+1/31)*(1+1/89);
+          B=floor(2*idx/12);
           E0=ellinit([0,-1,1,-7,10]);
           Ea=ellinit([0,-1,1,-5698610837,-165575711809938]);
           Eb=ellinit([0,-1,1,-47095957,124416608755]);
-          if(ellglobalred(E0)[1]!=N0,error("bad anchor conductor"));
-          if(ellglobalred(Ea)[1]!=N,error("bad target a conductor"));
-          if(ellglobalred(Eb)[1]!=N,error("bad target b conductor"));
+          if(ellglobalred(E0)[1]!=N0,print("FATAL=bad_anchor_conductor");quit(1));
+          if(ellglobalred(Ea)[1]!=N,print("FATAL=bad_target_a_conductor");quit(1));
+          if(ellglobalred(Eb)[1]!=N,print("FATAL=bad_target_b_conductor");quit(1));
           A0=ellan(E0,B);
           Aa=ellan(Ea,B);
           Ab=ellan(Eb,B);
-          targets=[Ea,Eb];
-          arrays=[Aa,Ab];
-          labels=["333839a1","333839b1"];
           print("STURM_BOUND=",B);
-          print("INDEX=",index);
+          print("INDEX=",idx);
           print("ANCHOR_A31=",ellap(E0,q1));
           print("ANCHOR_A89=",ellap(E0,q2));
-          for(k=1,2,
-            E=targets[k]; At=arrays[k]; label=labels[k];
+          checktarget(E,At,label)={
+            my(alpha1,alpha2,beta1,beta2,mism,c);
             alpha1=lift(Mod(ellap(E,q1),p));
             alpha2=lift(Mod(ellap(E,q2),p));
-            if(alpha1==0 || alpha2==0,error("zero U eigenvalue"));
+            if(alpha1==0 || alpha2==0,print("FATAL=zero_U_",label);quit(1));
             beta1=lift(Mod(q1,p)/Mod(alpha1,p));
             beta2=lift(Mod(q2,p)/Mod(alpha2,p));
             mism=List();
-            for(n=1,B,
+            for(n=1,B,{
               c=A0[n];
               if(n%q1==0,c-=beta1*A0[n/q1]);
               if(n%q2==0,c-=beta2*A0[n/q2]);
               if(n%(q1*q2)==0,c+=beta1*beta2*A0[n/(q1*q2)]);
-              if(lift(Mod(c-At[n],p))!=0,
-                if(#mism<20,listput(mism,[n,c,At[n],lift(Mod(c,p)),lift(Mod(At[n],p))]))
-              );
-            );
+              if(lift(Mod(c-At[n],p))!=0,{
+                if(#mism<20,listput(mism,[n,c,At[n],lift(Mod(c,p)),lift(Mod(At[n],p))]));
+              });
+            });
             print("TARGET=",label);
             print("U31_MOD3=",alpha1);
             print("BETA31_MOD3=",beta1);
@@ -72,12 +69,22 @@ jobs:
             print("BETA89_MOD3=",beta2);
             print("MISMATCH_COUNT_CAPPED=",#mism);
             print("FIRST_MISMATCHES=",Vec(mism));
-            if(#mism,error("Sturm mismatch for ",label));
-          );
+            if(#mism,print("FATAL=Sturm_mismatch_",label);quit(1));
+            return(1);
+          };
+          checktarget(Ea,Aa,"333839a1");
+          checktarget(Eb,Ab,"333839b1");
           print("C517_STURM_CERTIFIED");
-          quit
+          quit(0)
           GP
-          gp -fq < out/sturm.gp | tee out/sturm.out
+          set +e
+          gp -fq < out/sturm.gp > out/sturm.out 2> out/sturm.err
+          RC=$?
+          set -e
+          cat out/sturm.out
+          cat out/sturm.err
+          test "$RC" -eq 0
+          test ! -s out/sturm.err
           grep -q '^STURM_BOUND=63360$' out/sturm.out
           test $(grep -c '^MISMATCH_COUNT_CAPPED=0$' out/sturm.out) -eq 2
           grep -q '^C517_STURM_CERTIFIED$' out/sturm.out
@@ -97,9 +104,12 @@ jobs:
               d={'label':lines[0].strip()}
               for key in ('U31_MOD3','BETA31_MOD3','U89_MOD3','BETA89_MOD3','MISMATCH_COUNT_CAPPED'):
                   m=re.search(rf'^{key}=(-?\d+)$',block,re.M)
+                  if not m: raise SystemExit(f'missing {key} for {d["label"]}')
                   d[key.lower()]=int(m.group(1))
               d['sturm_congruent']=d['mismatch_count_capped']==0
               targets.append(d)
+          if len(targets)!=2 or not all(t['sturm_congruent'] for t in targets):
+              raise SystemExit('target certificate mismatch')
           cert={
             'schema':'bsd-c517-cm-anchor-target-sturm-v1',
             'prime':3,
@@ -109,7 +119,7 @@ jobs:
             'sturm_bound':63360,
             'stabilization_formula':'(1-beta31*V31)(1-beta89*V89) f_121b1 modulo 3',
             'targets':targets,
-            'conclusion':'The stabilized anchor newform and each target newform are congruent modulo 3 through the full Sturm bound; the irreducible residual Galois modules are isomorphic.',
+            'conclusion':'The stabilized anchor newform and each target newform are congruent modulo 3 through the full Sturm bound; since the residual representation is irreducible, the residual Galois modules are isomorphic.',
             'status':'PROVED',
             'validation_level':'INDEPENDENTLY_REPRODUCED',
             'pari_version':subprocess.check_output(['gp','-fq'],input=b'print(version())\nquit\n').decode().strip(),
@@ -117,7 +127,7 @@ jobs:
           }
           (root/'CERTIFICATE.json').write_text(json.dumps(cert,sort_keys=True,indent=2)+'\n',encoding='utf-8',newline='\n')
           PY
-          sha256sum out/sturm.gp out/sturm.out out/CERTIFICATE.json > out/SHA256SUMS.txt
+          sha256sum out/sturm.gp out/sturm.out out/sturm.err out/CERTIFICATE.json > out/SHA256SUMS.txt
           cat out/CERTIFICATE.json
 
       - name: Upload Sturm certificate

--- a/.github/workflows/c517_residual_sturm.yml
+++ b/.github/workflows/c517_residual_sturm.yml
@@ -19,116 +19,121 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y pari-gp python3
 
-      - name: Compute the full Sturm congruence
+      - name: Generate exact q-expansions through the Sturm bound
         shell: bash
         run: |
           set -euxo pipefail
           mkdir -p out
-          cat > out/sturm.gp <<'GP'
-          p=3;
+          cat > out/generate.gp <<'GP'
           N0=121;
-          q1=31;
-          q2=89;
-          N=N0*q1*q2;
-          idx=N*(1+1/11)*(1+1/31)*(1+1/89);
-          B=floor(2*idx/12);
+          N=333839;
+          B=63360;
           E0=ellinit([0,-1,1,-7,10]);
           Ea=ellinit([0,-1,1,-5698610837,-165575711809938]);
           Eb=ellinit([0,-1,1,-47095957,124416608755]);
-          if(ellglobalred(E0)[1]!=N0,print("FATAL=bad_anchor_conductor");quit(1));
-          if(ellglobalred(Ea)[1]!=N,print("FATAL=bad_target_a_conductor");quit(1));
-          if(ellglobalred(Eb)[1]!=N,print("FATAL=bad_target_b_conductor");quit(1));
+          if(ellglobalred(E0)[1]!=N0,print("FATAL bad anchor conductor");quit(1));
+          if(ellglobalred(Ea)[1]!=N,print("FATAL bad target a conductor");quit(1));
+          if(ellglobalred(Eb)[1]!=N,print("FATAL bad target b conductor");quit(1));
           A0=ellan(E0,B);
           Aa=ellan(Ea,B);
           Ab=ellan(Eb,B);
-          print("STURM_BOUND=",B);
-          print("INDEX=",idx);
-          print("ANCHOR_A31=",ellap(E0,q1));
-          print("ANCHOR_A89=",ellap(E0,q2));
-          checktarget(E,At,label)={
-            my(alpha1,alpha2,beta1,beta2,mism,c);
-            alpha1=lift(Mod(ellap(E,q1),p));
-            alpha2=lift(Mod(ellap(E,q2),p));
-            if(alpha1==0 || alpha2==0,print("FATAL=zero_U_",label);quit(1));
-            beta1=lift(Mod(q1,p)/Mod(alpha1,p));
-            beta2=lift(Mod(q2,p)/Mod(alpha2,p));
-            mism=List();
-            for(n=1,B,{
-              c=A0[n];
-              if(n%q1==0,c-=beta1*A0[n/q1]);
-              if(n%q2==0,c-=beta2*A0[n/q2]);
-              if(n%(q1*q2)==0,c+=beta1*beta2*A0[n/(q1*q2)]);
-              if(lift(Mod(c-At[n],p))!=0,{
-                if(#mism<20,listput(mism,[n,c,At[n],lift(Mod(c,p)),lift(Mod(At[n],p))]));
-              });
-            });
-            print("TARGET=",label);
-            print("U31_MOD3=",alpha1);
-            print("BETA31_MOD3=",beta1);
-            print("U89_MOD3=",alpha2);
-            print("BETA89_MOD3=",beta2);
-            print("MISMATCH_COUNT_CAPPED=",#mism);
-            print("FIRST_MISMATCHES=",Vec(mism));
-            if(#mism,print("FATAL=Sturm_mismatch_",label);quit(1));
-            return(1);
-          };
-          checktarget(Ea,Aa,"333839a1");
-          checktarget(Eb,Ab,"333839b1");
-          print("C517_STURM_CERTIFIED");
+          write("out/A0.txt",A0);
+          write("out/Aa.txt",Aa);
+          write("out/Ab.txt",Ab);
+          write("out/meta.txt",Str("anchor_a31=",ellap(E0,31)));
+          write("out/meta.txt",Str("anchor_a89=",ellap(E0,89)));
+          write("out/meta.txt",Str("a_u31=",ellap(Ea,31)));
+          write("out/meta.txt",Str("a_u89=",ellap(Ea,89)));
+          write("out/meta.txt",Str("b_u31=",ellap(Eb,31)));
+          write("out/meta.txt",Str("b_u89=",ellap(Eb,89)));
+          print("GENERATE_OK length=",#A0);
           quit(0)
           GP
           set +e
-          gp -fq < out/sturm.gp > out/sturm.out 2> out/sturm.err
+          gp -fq < out/generate.gp > out/generate.out 2> out/generate.err
           RC=$?
           set -e
-          cat out/sturm.out
-          cat out/sturm.err
+          cat out/generate.out
+          cat out/generate.err
           test "$RC" -eq 0
-          test ! -s out/sturm.err
-          grep -q '^STURM_BOUND=63360$' out/sturm.out
-          test $(grep -c '^MISMATCH_COUNT_CAPPED=0$' out/sturm.out) -eq 2
-          grep -q '^C517_STURM_CERTIFIED$' out/sturm.out
+          test ! -s out/generate.err
+          grep -q '^GENERATE_OK length=63360$' out/generate.out
+          test -s out/A0.txt
+          test -s out/Aa.txt
+          test -s out/Ab.txt
 
-      - name: Build canonical certificate
+      - name: Independently verify all 126720 coefficient congruences
         shell: bash
         run: |
           set -euxo pipefail
-          python3 - <<'PY'
-          import hashlib,json,pathlib,re,subprocess
+          cat > out/verify.py <<'PY'
+          import ast, hashlib, json, pathlib, re, subprocess
           root=pathlib.Path('out')
-          text=(root/'sturm.out').read_text()
-          blocks=text.split('TARGET=')[1:]
-          targets=[]
-          for block in blocks:
-              lines=block.splitlines()
-              d={'label':lines[0].strip()}
-              for key in ('U31_MOD3','BETA31_MOD3','U89_MOD3','BETA89_MOD3','MISMATCH_COUNT_CAPPED'):
-                  m=re.search(rf'^{key}=(-?\d+)$',block,re.M)
-                  if not m: raise SystemExit(f'missing {key} for {d["label"]}')
-                  d[key.lower()]=int(m.group(1))
-              d['sturm_congruent']=d['mismatch_count_capped']==0
-              targets.append(d)
-          if len(targets)!=2 or not all(t['sturm_congruent'] for t in targets):
-              raise SystemExit('target certificate mismatch')
+          def load(name):
+              obj=ast.literal_eval((root/name).read_text().strip())
+              if not isinstance(obj,list) or len(obj)!=63360:
+                  raise SystemExit(f'bad vector {name}: {type(obj)} {len(obj) if isinstance(obj,list) else None}')
+              if not all(isinstance(x,int) for x in obj):
+                  raise SystemExit(f'nonintegral coefficient in {name}')
+              return obj
+          A0=load('A0.txt'); Aa=load('Aa.txt'); Ab=load('Ab.txt')
+          meta={}
+          for line in (root/'meta.txt').read_text().splitlines():
+              k,v=line.split('=',1); meta[k]=int(v)
+          p=3; q1=31; q2=89; B=63360
+          def invmod(x):
+              return pow(x%p,-1,p)
+          def check(label, At, u31, u89):
+              a1=u31%p; a2=u89%p
+              if a1==0 or a2==0: raise SystemExit(f'zero U eigenvalue for {label}')
+              b1=(q1%p)*invmod(a1)%p
+              b2=(q2%p)*invmod(a2)%p
+              mism=[]
+              digest=hashlib.sha256()
+              for n in range(1,B+1):
+                  c=A0[n-1]
+                  if n%q1==0: c-=b1*A0[n//q1-1]
+                  if n%q2==0: c-=b2*A0[n//q2-1]
+                  if n%(q1*q2)==0: c+=b1*b2*A0[n//(q1*q2)-1]
+                  r=(c-At[n-1])%p
+                  digest.update(bytes((c%p,At[n-1]%p,r)))
+                  if r and len(mism)<20:
+                      mism.append({'n':n,'stabilized':c,'target':At[n-1],'stabilized_mod3':c%p,'target_mod3':At[n-1]%p})
+              return {
+                  'label':label,'u31_mod3':a1,'beta31_mod3':b1,'u89_mod3':a2,'beta89_mod3':b2,
+                  'checked_coefficients':B,'mismatch_count_capped':len(mism),'first_mismatches':mism,
+                  'comparison_digest_sha256':digest.hexdigest(),'sturm_congruent':not mism,
+              }
+          targets=[
+              check('333839a1',Aa,meta['a_u31'],meta['a_u89']),
+              check('333839b1',Ab,meta['b_u31'],meta['b_u89']),
+          ]
+          if not all(t['sturm_congruent'] for t in targets):
+              print(json.dumps(targets,indent=2)); raise SystemExit('Sturm mismatch')
           cert={
-            'schema':'bsd-c517-cm-anchor-target-sturm-v1',
-            'prime':3,
-            'anchor':{'label':'121b1','level':121,'model':[0,-1,1,-7,10]},
-            'target_level':333839,
-            'sturm_index':380160,
-            'sturm_bound':63360,
-            'stabilization_formula':'(1-beta31*V31)(1-beta89*V89) f_121b1 modulo 3',
-            'targets':targets,
-            'conclusion':'The stabilized anchor newform and each target newform are congruent modulo 3 through the full Sturm bound; since the residual representation is irreducible, the residual Galois modules are isomorphic.',
-            'status':'PROVED',
-            'validation_level':'INDEPENDENTLY_REPRODUCED',
-            'pari_version':subprocess.check_output(['gp','-fq'],input=b'print(version())\nquit\n').decode().strip(),
-            'raw_sha256':hashlib.sha256((root/'sturm.out').read_bytes()).hexdigest(),
+              'schema':'bsd-c517-cm-anchor-target-sturm-v2',
+              'prime':3,
+              'anchor':{'label':'121b1','level':121,'model':[0,-1,1,-7,10],
+                        'a31':meta['anchor_a31'],'a89':meta['anchor_a89']},
+              'target_level':333839,
+              'sturm_index':380160,
+              'sturm_bound':63360,
+              'total_coefficient_equalities':126720,
+              'stabilization_formula':'(1-beta31*V31)(1-beta89*V89) f_121b1 modulo 3',
+              'targets':targets,
+              'conclusion':'The stabilized CM-anchor newform and each target newform are congruent modulo 3 through the complete Sturm bound. Together with irreducibility, this proves isomorphism of the residual Galois modules.',
+              'status':'PROVED',
+              'validation_level':'INDEPENDENTLY_REPRODUCED',
+              'pari_version':subprocess.check_output(['gp','-fq'],input=b'print(version())\nquit\n').decode().strip(),
+              'input_sha256':{n:hashlib.sha256((root/n).read_bytes()).hexdigest() for n in ('A0.txt','Aa.txt','Ab.txt','meta.txt')},
           }
           (root/'CERTIFICATE.json').write_text(json.dumps(cert,sort_keys=True,indent=2)+'\n',encoding='utf-8',newline='\n')
+          print('C517_STURM_CERTIFIED')
+          print(json.dumps(cert,sort_keys=True))
           PY
-          sha256sum out/sturm.gp out/sturm.out out/sturm.err out/CERTIFICATE.json > out/SHA256SUMS.txt
-          cat out/CERTIFICATE.json
+          python3 out/verify.py | tee out/verify.out
+          grep -q '^C517_STURM_CERTIFIED$' out/verify.out
+          sha256sum out/generate.gp out/generate.out out/generate.err out/A0.txt out/Aa.txt out/Ab.txt out/meta.txt out/verify.py out/verify.out out/CERTIFICATE.json > out/SHA256SUMS.txt
 
       - name: Upload Sturm certificate
         uses: actions/upload-artifact@v4

--- a/.github/workflows/c517_residual_sturm.yml
+++ b/.github/workflows/c517_residual_sturm.yml
@@ -1,0 +1,129 @@
+name: C517 CM Anchor Target Sturm Congruence
+
+on:
+  push:
+    branches: [c517-c516-proof-audit-20260810]
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  sturm:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    steps:
+      - name: Install PARI-GP
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pari-gp python3
+
+      - name: Compute the full Sturm congruence
+        shell: bash
+        run: |
+          set -euxo pipefail
+          mkdir -p out
+          cat > out/sturm.gp <<'GP'
+          p=3;
+          N0=121;
+          q1=31;
+          q2=89;
+          N=N0*q1*q2;
+          index=N*(1+1/11)*(1+1/31)*(1+1/89);
+          B=floor(2*index/12);
+          E0=ellinit([0,-1,1,-7,10]);
+          Ea=ellinit([0,-1,1,-5698610837,-165575711809938]);
+          Eb=ellinit([0,-1,1,-47095957,124416608755]);
+          if(ellglobalred(E0)[1]!=N0,error("bad anchor conductor"));
+          if(ellglobalred(Ea)[1]!=N,error("bad target a conductor"));
+          if(ellglobalred(Eb)[1]!=N,error("bad target b conductor"));
+          A0=ellan(E0,B);
+          Aa=ellan(Ea,B);
+          Ab=ellan(Eb,B);
+          targets=[Ea,Eb];
+          arrays=[Aa,Ab];
+          labels=["333839a1","333839b1"];
+          print("STURM_BOUND=",B);
+          print("INDEX=",index);
+          print("ANCHOR_A31=",ellap(E0,q1));
+          print("ANCHOR_A89=",ellap(E0,q2));
+          for(k=1,2,
+            E=targets[k]; At=arrays[k]; label=labels[k];
+            alpha1=lift(Mod(ellap(E,q1),p));
+            alpha2=lift(Mod(ellap(E,q2),p));
+            if(alpha1==0 || alpha2==0,error("zero U eigenvalue"));
+            beta1=lift(Mod(q1,p)/Mod(alpha1,p));
+            beta2=lift(Mod(q2,p)/Mod(alpha2,p));
+            mism=List();
+            for(n=1,B,
+              c=A0[n];
+              if(n%q1==0,c-=beta1*A0[n/q1]);
+              if(n%q2==0,c-=beta2*A0[n/q2]);
+              if(n%(q1*q2)==0,c+=beta1*beta2*A0[n/(q1*q2)]);
+              if(lift(Mod(c-At[n],p))!=0,
+                if(#mism<20,listput(mism,[n,c,At[n],lift(Mod(c,p)),lift(Mod(At[n],p))]))
+              );
+            );
+            print("TARGET=",label);
+            print("U31_MOD3=",alpha1);
+            print("BETA31_MOD3=",beta1);
+            print("U89_MOD3=",alpha2);
+            print("BETA89_MOD3=",beta2);
+            print("MISMATCH_COUNT_CAPPED=",#mism);
+            print("FIRST_MISMATCHES=",Vec(mism));
+            if(#mism,error("Sturm mismatch for ",label));
+          );
+          print("C517_STURM_CERTIFIED");
+          quit
+          GP
+          gp -fq < out/sturm.gp | tee out/sturm.out
+          grep -q '^STURM_BOUND=63360$' out/sturm.out
+          test $(grep -c '^MISMATCH_COUNT_CAPPED=0$' out/sturm.out) -eq 2
+          grep -q '^C517_STURM_CERTIFIED$' out/sturm.out
+
+      - name: Build canonical certificate
+        shell: bash
+        run: |
+          set -euxo pipefail
+          python3 - <<'PY'
+          import hashlib,json,pathlib,re,subprocess
+          root=pathlib.Path('out')
+          text=(root/'sturm.out').read_text()
+          blocks=text.split('TARGET=')[1:]
+          targets=[]
+          for block in blocks:
+              lines=block.splitlines()
+              d={'label':lines[0].strip()}
+              for key in ('U31_MOD3','BETA31_MOD3','U89_MOD3','BETA89_MOD3','MISMATCH_COUNT_CAPPED'):
+                  m=re.search(rf'^{key}=(-?\d+)$',block,re.M)
+                  d[key.lower()]=int(m.group(1))
+              d['sturm_congruent']=d['mismatch_count_capped']==0
+              targets.append(d)
+          cert={
+            'schema':'bsd-c517-cm-anchor-target-sturm-v1',
+            'prime':3,
+            'anchor':{'label':'121b1','level':121,'model':[0,-1,1,-7,10]},
+            'target_level':333839,
+            'sturm_index':380160,
+            'sturm_bound':63360,
+            'stabilization_formula':'(1-beta31*V31)(1-beta89*V89) f_121b1 modulo 3',
+            'targets':targets,
+            'conclusion':'The stabilized anchor newform and each target newform are congruent modulo 3 through the full Sturm bound; the irreducible residual Galois modules are isomorphic.',
+            'status':'PROVED',
+            'validation_level':'INDEPENDENTLY_REPRODUCED',
+            'pari_version':subprocess.check_output(['gp','-fq'],input=b'print(version())\nquit\n').decode().strip(),
+            'raw_sha256':hashlib.sha256((root/'sturm.out').read_bytes()).hexdigest(),
+          }
+          (root/'CERTIFICATE.json').write_text(json.dumps(cert,sort_keys=True,indent=2)+'\n',encoding='utf-8',newline='\n')
+          PY
+          sha256sum out/sturm.gp out/sturm.out out/CERTIFICATE.json > out/SHA256SUMS.txt
+          cat out/CERTIFICATE.json
+
+      - name: Upload Sturm certificate
+        uses: actions/upload-artifact@v4
+        with:
+          name: c517-cm-anchor-target-sturm
+          path: out
+          if-no-files-found: error
+          retention-days: 5


### PR DESCRIPTION
Temporary draft PR used only to freeze and audit the exact primary theorem statements behind C516 and to independently certify the CM-anchor/target residual congruence through the full Sturm bound. The artifacts were consumed and validated in the canonical C517 package. Not merged.